### PR TITLE
Fix for issue #4 - Adding the ability to have --long commands

### DIFF
--- a/generators/app/templates/sub/help.js
+++ b/generators/app/templates/sub/help.js
@@ -117,10 +117,10 @@ function showCommands(logger, commands, resolve, reject, showLong) {
 /**
  * Gets help for a sub command.
  * Usage:
- *      blah help example
+ *      <%= name %> help example
  *      > An example command.
  *      > Usage:
- *      >      blah example
+ *      >      <%= name %> example
  *      >      > 'You ran the example command!'
  */
 module.exports = function ({ argv, logger, sub }) {

--- a/generators/app/templates/sub/help.js
+++ b/generators/app/templates/sub/help.js
@@ -4,22 +4,37 @@ const fs = require('fs');
 const libDir = __dirname;
 const path = require('path');
 
+
+
   /**
-   * Gets the help text for a command.
-   * @param  {String} fileName The name of the command to get the help text for.
-   * @return {String}          The first line of the help text.
+   * Returns the lines of the given that are top-level comments
+   * @param {String} fileName The name of the file to find comment lines for.
+   * @return {Array.<String>} An array of strings that are top-level comments
    */
-function getHelpText(fileName) {
+function getHelpLines(fileName) {
   const file = fs.readFileSync(path.join(libDir, fileName + '.js')).toString();
   const lines = file.split('\n');
+
   const commentCharacters = ['*/', ' */', ' *', '/**', '/*', '*', '//'];
-  const escapedCommentCharacters = [' \*/', '\*/', ' \*', '/\*', '\*', '//'];
 
   const helpLines = lines.filter((line) => {
     // Include any top-level comments as help text (indented comments should be excluded so you can comment on the
     // internals without leaking any implementation details).
     return commentCharacters.reduce((prev, curr) => prev || line.startsWith(curr), false);
   });
+
+  return helpLines;
+}
+
+  /**
+   * Gets the help text for a command.
+   * @param  {String} fileName The name of the command to get the help text for.
+   * @return {String}          The first line of the help text.
+   */
+function getHelpText(fileName) {
+  const helpLines = getHelpLines(fileName)
+  
+  const escapedCommentCharacters = [' \*/', '\*/', ' \*', '/\*', '\*', '//'];
 
   const uncommentedLines = helpLines.map((line) => {
     escapedCommentCharacters.forEach((char) => {
@@ -42,6 +57,19 @@ function getFirstLine(fileName) {
   return getHelpText(fileName)[0];
 }
 
+  /**
+   * Returns whether or not the command is considered a "long" only command.
+   * This is determined by whether or not a top level comment contains the
+   * annotation "@kind internal".
+   * @param {String} filename The name of the command to test against.
+   * @return {boolean}        Whether or not this command is considered a "long" command
+   */
+function isLongCommand(fileName) {
+  const longTest = /@kind\s+internal/;
+  const lines = getHelpLines(fileName);
+  return lines.some((line) => longTest.test(line));
+}
+
 /**
  * Gets help for a sub command.
  * Usage:
@@ -54,7 +82,16 @@ function getFirstLine(fileName) {
 module.exports = function ({ argv, logger, sub }) {
   return new Promise((resolve, reject) => {
     sub.get().then((commands) => {
-      const helpSub = argv ? argv._[1] : undefined;
+      const secondaryCommand = argv ? argv._[1] : undefined;
+      let showLong = false;
+      let helpSub = null;
+      if (secondaryCommand) {
+        if (secondaryCommand === "--long") {
+          showLong = true;
+        } else {
+          helpSub = secondaryCommand;
+        }  
+      }
 
       if (helpSub) {
         if (commands.has(helpSub)) {
@@ -67,10 +104,26 @@ module.exports = function ({ argv, logger, sub }) {
           reject();
         }
       } else {
-
         logger.info('A simple cli application. Broken into sub commands, invoked under sub: ');
-        commands.forEach((s) => logger.info('    ' + s + ': ' + getFirstLine(s)));
-        logger.info('Also takes the flag --noUpdate to prevent auto updating.');
+
+        const longCommands = commands.filter(isLongCommand);
+        const basicCommands = commands.filter(command => !isLongCommand(command));
+
+        if (basicCommands.length) {
+          basicCommands.forEach(s => logger.info('    ' + s + ': ' + getFirstLine(s)));  
+        }
+
+        if (longCommands.length) {
+          if (showLong) {
+            logger.info('');
+            logger.info('These commands are marked as "internal":');
+            longCommands.forEach(s => logger.info('    ' + s + ': ' + getFirstLine(s)));
+            logger.info('');
+            logger.info('Also takes the flag --noUpdate to prevent auto updating.');  
+          } else {
+            logger.info('There are more, internal commands that can be shown with the --long flag');
+          }
+        }
         resolve();
       }
     }, reject);

--- a/generators/command/index.js
+++ b/generators/command/index.js
@@ -13,11 +13,18 @@ module.exports = yeoman.generators.Base.extend({
       'Welcome to the kryptonian ' + chalk.red('generator-sub') + ' generator!'
     ));
 
-    var prompts = [{
-      type   : 'input',
-      name   : 'name',
-      message: 'What would you like to call your sub command?'
-    }];
+    var prompts = [
+      {
+        type   : 'input',
+        name   : 'name',
+        message: 'What would you like to call your sub command?'
+      },
+      {
+        type   :'confirm',
+        name   :'isInternal',
+        message:'Should this be an internal command? (Only shown with --long)'
+      }
+    ];
 
     this.prompt(prompts, function (props) {
       this.props = props;
@@ -29,7 +36,8 @@ module.exports = yeoman.generators.Base.extend({
 
   writing: function () {
     var context = {
-      name: this.props.name
+      name: this.props.name,
+      isInternal: this.props.isInternal
     };
 
     this.template('command.js', path.join('sub', this.props.name + '.js'), context);

--- a/generators/command/templates/command.js
+++ b/generators/command/templates/command.js
@@ -5,6 +5,9 @@
  * Usage:
  *     <%= name %>
  *     > 'You ran the <%= name %> command!'
+<% if (isInternal) { %>
+ * @kind internal
+<% } %>
  */
 module.exports = function ({ argv, config, logger }) {
   return new Promise((resolve) => {

--- a/generators/command/templates/command.js
+++ b/generators/command/templates/command.js
@@ -5,9 +5,9 @@
  * Usage:
  *     <%= name %>
  *     > 'You ran the <%= name %> command!'
-<% if (isInternal) { %>
+<% if (isInternal) { -%>
  * @kind internal
-<% } %>
+<% } -%>
  */
 module.exports = function ({ argv, config, logger }) {
   return new Promise((resolve) => {


### PR DESCRIPTION
Long commands are indicated by the existence of an `@kind internal` annotation in a top-level command. This also adjusts the output in a few ways:

![image](https://cloud.githubusercontent.com/assets/1928182/16369000/ca87204e-3be9-11e6-89ee-9bc46a492c25.png)
